### PR TITLE
Fix/eks workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.19 AS builder
+
+WORKDIR /app
+
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+COPY . .
+
+ARG VERSION
+
+RUN go build -o bin/vulpine -v -ldflags="-X main.version=$VERSION" 
+
+FROM gcr.io/distroless/base-debian10
+
+COPY --from=builder /app/bin /bin/
+
+ENTRYPOINT ["/bin/vulpine"]

--- a/pkg/ecr/ecr.go
+++ b/pkg/ecr/ecr.go
@@ -3,7 +3,6 @@ package ecr
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
@@ -17,9 +16,8 @@ type ECRRepo struct {
 }
 
 type RepoImage struct {
-	ImageDigest   string
-	ImageTag      string
-	ImageDeployed bool
+	ImageDigest string
+	ImageTag    string
 }
 
 func GenerateEcrImageList(cfg aws.Config) []ECRRepo {
@@ -28,7 +26,7 @@ func GenerateEcrImageList(cfg aws.Config) []ECRRepo {
 	var ecrRepo []ECRRepo
 
 	repos, err := client.DescribeRepositories(context.TODO(), &ecr.DescribeRepositoriesInput{
-		MaxResults: aws.Int32(350),
+		MaxResults: aws.Int32(500),
 	})
 	if err != nil {
 		fmt.Printf("Unable to list repositories, %v", err.Error())
@@ -61,36 +59,10 @@ func GenerateEcrImageList(cfg aws.Config) []ECRRepo {
 			if image.ImageTag == nil {
 				image.ImageTag = aws.String("untagged")
 			}
-			repoImages = append(repoImages, RepoImage{*image.ImageDigest, *image.ImageTag, false})
+			repoImages = append(repoImages, RepoImage{*image.ImageDigest, *image.ImageTag})
 		}
 
 		ecrRepo = append(ecrRepo, ECRRepo{*repo.RepositoryName, repoArn, repoImages, repoTags})
 	}
 	return ecrRepo
-}
-
-func ImageLookup(ecrRepos []ECRRepo, digestLookup string) (string, string, bool) {
-
-	if digestLookup != "" {
-		digestLookup = strings.Split(digestLookup, "@")[1]
-		fmt.Println("Length of ecrRepos:", len(ecrRepos))
-		for _, repo := range ecrRepos {
-			fmt.Printf("Working on repo: %s\n", repo.RepositoryName)
-			for _, image := range repo.RepoImages {
-				fmt.Printf("Working on repo image %s\n", image.ImageDigest)
-				if digestLookup != "" {
-
-					if image.ImageDigest == digestLookup {
-						return repo.RepositoryName, image.ImageDigest, true
-
-					} else {
-					}
-				}
-
-			}
-		}
-
-	}
-
-	return "", "", false
 }

--- a/pkg/eks/eks.go
+++ b/pkg/eks/eks.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/rootameen/vulpine/pkg/ecr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -135,17 +134,4 @@ func GetPods(clientSet *kubernetes.Clientset, pods []Pod) []Pod {
 		}
 	}
 	return pods
-}
-
-func IsImageDeployed(ecrRepos []ecr.ECRRepo, pods []Pod, deployedImages map[string]string) {
-	for i, repo := range ecrRepos {
-		for j, image := range repo.RepoImages {
-			for _, pod := range pods {
-				if pod.Repo == repo.RepositoryName && pod.ImageID == image.ImageDigest {
-					ecrRepos[i].RepoImages[j].ImageDeployed = true
-					deployedImages[repo.RepositoryName] = pod.ImageTag
-				}
-			}
-		}
-	}
 }

--- a/pkg/inspector/inspector.go
+++ b/pkg/inspector/inspector.go
@@ -89,7 +89,6 @@ func ListInspectorFindingsEcr(client *inspector2.Client, results []types.Finding
 				panic("Error in Listing findings from Next Token, " + err.Error())
 			}
 			results = append(results, findings.Findings...)
-			fmt.Println(len(results))
 		}
 	}
 
@@ -181,7 +180,6 @@ func ListInspectorFindingsByRepoImage(client *inspector2.Client, results []types
 			panic("Error in Listing findings from Next Token, " + err.Error())
 		}
 		results = append(results, findings.Findings...)
-		fmt.Println(len(results))
 	}
 
 	return results

--- a/pkg/scan/scan.go
+++ b/pkg/scan/scan.go
@@ -16,11 +16,9 @@ func ScanFindings(scanTarget *string, results []types.Finding, inspectorClient *
 		results = inspector.ListInspectorFindingsEcr(inspectorClient, results, scanType, ecrImageRegistry)
 	} else if *scanTarget == "eks" {
 		pods := eks.GenerateClusterImageList(k8sctx)
-		deployedImages := make(map[string]string)
-		eks.IsImageDeployed(ecrRepos, pods, deployedImages)
-		for repoName, imageTag := range deployedImages {
-			fmt.Println("Obtaining findings for running image: ", repoName, imageTag)
-			results = inspector.ListInspectorFindingsByRepoImage(inspectorClient, results, repoName, imageTag)
+		for _, pod := range pods {
+			fmt.Printf("** Obtaining findings for running pod: Repo: %s, ImageTag: %s\n", pod.Repo, pod.ImageTag)
+			results = inspector.ListInspectorFindingsByRepoImage(inspectorClient, results, pod.Repo, pod.ImageTag)
 		}
 	}
 	return results


### PR DESCRIPTION
[feat: add Dockerfile](https://github.com/rootameen/vulpine/commit/f49f8d1e408a64398bfeebd844e066e73689c41b)
[chore: cleanup RepoImage struct, and remove unused func](https://github.com/rootameen/vulpine/commit/35c7aaa89f323afc8506be47a14494ffff705026)
[chore: remove cross dependency, and remove no longer needed func](https://github.com/rootameen/vulpine/commit/aa9b7192db09b156f2b66919aadc14a2833640bd)
[chore: remove unneeded print](https://github.com/rootameen/vulpine/commit/05ddc5e4a8e954df8d9eefa6c5b778fe5cbb852a)
[fix: rework the eks scan func to avoid using an extra map to find pod's running status](https://github.com/rootameen/vulpine/commit/71df87bbce18e35adc32a2678dea60c7e488172b) 

Primarily with the last commit, previous behaviour was relying on matching whatever is in the ECR repos, and then checking if they were also running on eks. With EKS mode, this is no longer required as the running images obtained from within the cluster is the source of truth. 
