### PR TITLE
chore: Update Base Image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG VERSION
 
 RUN go build -o bin/vulpine -v -ldflags="-X main.version=$VERSION" 
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian12
 
 COPY --from=builder /app/bin /bin/
 


### PR DESCRIPTION
chore: Update Base Image in Dockerfile. This resolved a bunch of security vulnerabilities, as well. 